### PR TITLE
#60 Display commandline args when none are given

### DIFF
--- a/src/GitLink.Tests/ArgumentParserFacts.cs
+++ b/src/GitLink.Tests/ArgumentParserFacts.cs
@@ -14,9 +14,10 @@ namespace GitLink.Tests
     public class ArgumentParserFacts
     {
         [TestCase]
-        public void ThrowsExceptionForEmptyParameters()
+        public void ReturnsHelpForEmptyParameters()
         {
-            ExceptionTester.CallMethodAndExpectException<GitLinkException>(() => ArgumentParser.ParseArguments(string.Empty));
+            var context = ArgumentParser.ParseArguments(string.Empty);
+            Assert.IsTrue(context.IsHelp);
         }
 
         [TestCase]

--- a/src/GitLink/ArgumentParser.cs
+++ b/src/GitLink/ArgumentParser.cs
@@ -38,7 +38,8 @@ namespace GitLink
 
             if (commandLineArguments.Count == 0)
             {
-                Log.ErrorAndThrowException<GitLinkException>("Invalid number of arguments");
+                context.IsHelp = true;
+                return context;
             }
 
             var firstArgument = commandLineArguments.First();


### PR DESCRIPTION
The fix defaults to help text if aren't any. Prior to this it was
throwing an exception which wasn't helpful to the users.
